### PR TITLE
make create clustermonitor optional

### DIFF
--- a/jobs/mongodb_exporter/spec
+++ b/jobs/mongodb_exporter/spec
@@ -30,6 +30,9 @@ properties:
     description: "Collect MongoDB indexusage metrics"
   mongodb.bin_path:
     description: "Where mongoDB binaries are on the deployment"
+  mongodb.clustermonitor.create:
+    description: "Auto create the clustermonitor user"
+    default: true
   mongodb.clustermonitor.username:
     description: "User used for mongodb exporter"
   mongodb.clustermonitor.password:

--- a/jobs/mongodb_exporter/templates/bin/create_clustermonitor_user.sh
+++ b/jobs/mongodb_exporter/templates/bin/create_clustermonitor_user.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 
+# create file content only when clustermonitor user should be created
+<%- if p('mongodb.clustermonitor.create') == true -%>
+
 <%-
   require "shellwords"
 
@@ -113,3 +116,5 @@ if [ "${Master}" == "<%= esc(current_ip) %>" ]
 then
     ${MONGO_CMD} ${CONNECT_STRING} $JOB_DIR/js/create_clustermonitor_user.js
 fi
+
+<%- end -%>

--- a/jobs/mongodb_exporter/templates/bin/mongodb_exporter_ctl
+++ b/jobs/mongodb_exporter/templates/bin/mongodb_exporter_ctl
@@ -22,8 +22,10 @@ case $1 in
     echo $$ > ${PIDFILE}
 
     # create clustermonitor user
-    JOB_DIR=/var/vcap/jobs/mongodb_exporter
-    source ${JOB_DIR}/bin/create_clustermonitor_user.sh
+    <%- if p('mongodb.clustermonitor.create') == true -%>
+      JOB_DIR=/var/vcap/jobs/mongodb_exporter
+      source ${JOB_DIR}/bin/create_clustermonitor_user.sh
+    <%- end -%>
 
     # export MONGODB_URL="<%= p('mongodb.uri') %>"
 

--- a/jobs/mongodb_exporter/templates/js/create_clustermonitor_user.js
+++ b/jobs/mongodb_exporter/templates/js/create_clustermonitor_user.js
@@ -1,3 +1,4 @@
+<%- if p('mongodb.clustermonitor.create') == true -%>
 if (db.system.users.find({ user: "<%= p('mongodb.clustermonitor.username') %>" }).count() == 0) {
     db.createUser({
         user: "<%= p('mongodb.clustermonitor.username') %>",
@@ -10,3 +11,4 @@ if (db.system.users.find({ user: "<%= p('mongodb.clustermonitor.username') %>" }
 } else {
     db.changeUserPassword("<%= p('mongodb.clustermonitor.username') %>", "<%= p('mongodb.clustermonitor.password') %>");
 }
+<%- end -%>


### PR DESCRIPTION
Add a new property `mongodb.clustermonitor.create` to make create clustermonitor optional.